### PR TITLE
Allow newer versions of dflydev/dot-access-data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require": {
         "php": ">=7.1.3",
-        "dflydev/dot-access-data": "^1.1.0"
+        "dflydev/dot-access-data": "^1.1.0 || ^2.0.0 || ^3.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.20 || ^8 || ^9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,41 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94f6561fc7eeabbc255fbc7750e59caa",
+    "content-hash": "93a8ff1581bccfea6b0cab724c7ba1e1",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
-            "version": "v1.1.0",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
-                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a"
+                "reference": "0992cc19268b259a39e86f296da5f0677841f42c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/3fbd874921ab2c041e899d044585a2ab9795df8a",
-                "reference": "3fbd874921ab2c041e899d044585a2ab9795df8a",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/0992cc19268b259a39e86f296da5f0677841f42c",
+                "reference": "0992cc19268b259a39e86f296da5f0677841f42c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
+                "scrutinizer/ocular": "1.6.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^3.14"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Dflydev\\DotAccessData": "src"
+                "psr-4": {
+                    "Dflydev\\DotAccessData\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -53,6 +60,11 @@
                     "name": "Carlos Frutos",
                     "email": "carlos@kiwing.it",
                     "homepage": "https://github.com/cfrutos"
+                },
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com"
                 }
             ],
             "description": "Given a deep data structure, access data by dot notation.",
@@ -65,9 +77,9 @@
             ],
             "support": {
                 "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
-                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/master"
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.1"
             },
-            "time": "2017-01-20T21:14:22+00:00"
+            "time": "2021-08-13T13:06:58+00:00"
         }
     ],
     "packages-dev": [
@@ -1976,5 +1988,5 @@
     "platform-overrides": {
         "php": "7.2.28"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/src/Operators/ContainsOp.php
+++ b/src/Operators/ContainsOp.php
@@ -3,6 +3,7 @@ namespace Consolidation\Filter\Operators;
 
 use Consolidation\Filter\OperatorInterface;
 use Dflydev\DotAccessData\Data;
+use Dflydev\DotAccessData\Exception\DataException;
 
 /**
  * Test for equality
@@ -26,7 +27,12 @@ class ContainsOp implements OperatorInterface
      */
     public function test(Data $row)
     {
-        $value = $row->get($this->key);
+        try {
+            $value = $row->get($this->key);
+        } catch (DataException $e) {
+            return false;
+        }
+
         if (is_array($value)) {
             return in_array($this->comparitor, $value);
         }

--- a/src/Operators/EqualsOp.php
+++ b/src/Operators/EqualsOp.php
@@ -3,6 +3,7 @@ namespace Consolidation\Filter\Operators;
 
 use Consolidation\Filter\OperatorInterface;
 use Dflydev\DotAccessData\Data;
+use Dflydev\DotAccessData\Exception\DataException;
 
 /**
  * Test for equality
@@ -26,7 +27,12 @@ class EqualsOp implements OperatorInterface
      */
     public function test(Data $row)
     {
-        $value = $row->get($this->key);
+        try {
+            $value = $row->get($this->key);
+        } catch (DataException $e) {
+            return false;
+        }
+
         return strcasecmp($this->comparitor, $value) == 0;
     }
 

--- a/src/Operators/RegexOp.php
+++ b/src/Operators/RegexOp.php
@@ -3,6 +3,7 @@ namespace Consolidation\Filter\Operators;
 
 use Consolidation\Filter\OperatorInterface;
 use Dflydev\DotAccessData\Data;
+use Dflydev\DotAccessData\Exception\DataException;
 
 /**
  * Test for equality
@@ -26,7 +27,12 @@ class RegexOp implements OperatorInterface
      */
     public function test(Data $row)
     {
-        $value = $row->get($this->key);
+        try {
+            $value = $row->get($this->key);
+        } catch (DataException $e) {
+            return false;
+        }
+
         return preg_match($this->comparitor, $value);
     }
 


### PR DESCRIPTION
### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Has tests?    | n/a
| BC breaks?    | no     
| Deprecations? | no 

### Summary
Allows newer versions of dflydev/dot-access-data to be installed.

### Description
Newer versions of dot-access-data will throw exceptions instead of returning null when non-existent data paths are given, so we simply need to wrap those calls and `return false` if any such exception is thrown.  This should be a backward-compatible change for this library and all dependents.

Allowing newer versions of dflydev/dot-access-data will also resolve a dependency conflict between league/commonmark v2 (which indirectly needs dot-access-data v3) and Drush (which relies on this library).
