### PR TITLE
Add the default filter option dynamically

### DIFF
--- a/src/Hooks/FilterHooks.php
+++ b/src/Hooks/FilterHooks.php
@@ -2,17 +2,32 @@
 
 namespace Consolidation\Filter\Hooks;
 
+use Consolidation\AnnotatedCommand\AnnotatedCommand;
+use Consolidation\AnnotatedCommand\AnnotationData;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\Filter\LogicalOpFactory;
 use Consolidation\Filter\FilterOutputData;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Yaml\Yaml;
 
 class FilterHooks
 {
+
+    /**
+     * @hook option *
+     */
+    public function addFilterOption(AnnotatedCommand $command, AnnotationData $annotationData)
+    {
+        if ($annotationData->has('filter-output')) {
+            if (!$command->getDefinition()->hasOption('filter')) {
+                // Add the default filter option if the command hasn't defined one.
+                $command->addOption('filter', null, InputOption::VALUE_OPTIONAL, 'Filter output based on provided expression', '');
+            }
+        }
+    }
+
     /**
      * @hook alter @filter-output
-     * @option $filter Filter output based on provided expression
-     * @default $filter ''
      */
     public function filterOutput($result, CommandData $commandData)
     {


### PR DESCRIPTION
The following exception is thrown whenever a command attempts to specify a default filter option for its command:
```
An option named "filter" already exists.
```

### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | yes/no 

### Summary
Moved the option declaration into a dedicated function to avoid an attempt to readd the filter option if it already exists in the command (which is necessary if the command needs a default filter value that isn't `''`.
